### PR TITLE
Fix typing errors & improve readibility

### DIFF
--- a/tests/dummy/app/templates/service-class.hbs
+++ b/tests/dummy/app/templates/service-class.hbs
@@ -12,7 +12,7 @@
   <content.P>
     There are two reasons which you may want to use this service. The first would be to manually remove
     a tracked value in the local storage which is linked to a <code class="inline-code">@trackedInLocalStorage</code> decorator in another file.
-    For example, this <code class="inline-code">componentProp</code> property which is sycned to a component:
+    For example, this <code class="inline-code">componentProp</code> property which is synced to a component:
   </content.P>
 
   <content.Code

--- a/tests/dummy/app/templates/tracked-local-storage-service-api.hbs
+++ b/tests/dummy/app/templates/tracked-local-storage-service-api.hbs
@@ -50,7 +50,7 @@
         <code class="inline-code">key(num:number)</code>
         <div class="italic mb-1">returns: null|any</div>
         <div>
-          Retreives the key at the specified number in local storage.
+          Retrieves the key at the specified number in local storage.
         </div>
       </li>
       <li>

--- a/tests/dummy/app/templates/tracked-local-storage-service-api.hbs
+++ b/tests/dummy/app/templates/tracked-local-storage-service-api.hbs
@@ -20,7 +20,7 @@
     <ul class="list-disc pl-8">
       <li class="mb-8">
         <code class="inline-code">getItem(keyName:string, skipPrefixes:string[])</code>
-        <div class="italic mb-1">returns: null|any</div>
+        <div class="italic mb-1">returns: null | any</div>
         <p class="mb-2">
           Gets an specified item from local storage. Accepts an optional second arg to ignore listed prefixes.
         </p>
@@ -48,14 +48,14 @@
       </li>
       <li class="mb-8">
         <code class="inline-code">key(num:number)</code>
-        <div class="italic mb-1">returns: null|any</div>
+        <div class="italic mb-1">returns: null | any</div>
         <div>
           Retrieves the key at the specified number in local storage.
         </div>
       </li>
       <li>
         <code class="inline-code">setGlobalPrefix(name:string, value:string)</code>
-        <div class="italic mb-1">returns: null|any</div>
+        <div class="italic mb-1">returns: null | any</div>
         <div>
           Sets a global prefix to be used whenever accessing a local storage value. More info can be found <LinkTo class="text-blue" @route="global-prefixes">here</LinkTo>.
         </div>


### PR DESCRIPTION
- Fix typing errors

- Improve readability by spacing out TypeScript types, see before/after:

  | Before | After |
  |--------|-------|
  | ![00 before](https://user-images.githubusercontent.com/47531779/132666725-f73efce3-7b31-4c9e-b81d-07d93ad9a3b6.png) | ![01 after](https://user-images.githubusercontent.com/47531779/132666727-0b39a3e0-90ee-4a49-87a0-fd8d39c7eeaf.png)
