### PR TITLE
fix: for embroider/vite: No matching export for { default } in addon/utils /tracked-in-local-storage.js

### DIFF
--- a/app/utils/tracked-in-local-storage.js
+++ b/app/utils/tracked-in-local-storage.js
@@ -1,5 +1,4 @@
 export {
-  default,
   localStorageGet,
   localStorageSet,
   trackedInLocalStorage,


### PR DESCRIPTION
Fix error in embroider/vite:

```
No matching export in "node_modules/.embroider/rewritten-packages/ember-tracked-local-storage.a84501d5/node_modules/ember-tracked-local-storage/utils/tracked-in-local-storage.js" for import "default"

    node_modules/.embroider/rewritten-packages/ember-tracked-local-storage.a84501d5/node_modules/ember-tracked-local-storage/_app_/utils/tracked-in-local-storage.js:1:9:
      1 │ export {
  default,
  localStorageGet,
  localStorageSet,
  trackedInLocalStorage,
} from 'ember-tracked-local-storage/utils/tracked-in-local-storage';
```